### PR TITLE
📦 Change to eslint and tsc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@essential-projects/eslint-config"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "5minds-typescript/fast",
-  "rules": {
-    "@typescript-eslint/no-explicit-any": ["warning"]
-  }
-}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,7 @@ pipeline {
     stage('lint') {
       steps {
         sh('node --version')
-        /* we do not want the linting to cause a failed build */
-        sh('npm run lint || true')
+        sh('npm run lint')
       }
     }
     stage('build') {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
+  "author": "5Minds IT-Solutions GmbH & Co. KG",
   "contributors": [
+    "Christian Werner <christian.werner@5minds.de>",
     "Heiko Mathes <heiko.mathes@5minds.de>"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,10 @@
     "cron": "^1.7.1"
   },
   "devDependencies": {
+    "@essential-projects/eslint-config": "^1.0.0",
     "@types/node": "^10.12.2",
-    "@typescript-eslint/eslint-plugin": "^1.7.0",
-    "@typescript-eslint/parser": "^1.7.0",
-    "eslint-config-5minds-typescript": "^1.0.0",
-    "eslint-plugin-6river": "^1.0.6",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-no-null": "^1.0.2",
+    "eslint": "^5.16.0",
+    "tsconfig": "^7.0.0",
     "typescript": "^3.4.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "the referencable contracts for scheduler",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "typescript": "^3.4.5"
   },
   "scripts": {
-    "build": "npm run build-commonjs && npm run build-amd",
+    "clean": "rm -rf dist",
+    "build": "npm run clean && npm run build-commonjs && npm run build-amd",
     "build-commonjs": "tsc",
     "build-amd": "tsc --module amd --outDir ./dist/amd",
     "prepare": "npm run build",
-    "lint": "eslint --fix src/**/*.ts",
+    "lint": "eslint src/*.ts",
+    "lint-fix": "eslint --fix src/*.ts",
     "test": ":"
   }
 }

--- a/src/ischeduler_controller.ts
+++ b/src/ischeduler_controller.ts
@@ -1,6 +1,6 @@
-import {CronJob, CronCommand} from 'cron';
+import {CronCommand, CronJob} from 'cron';
 
 export interface ISchedulerController {
   jobs: Array<CronJob>;
-  registerJob(schedule: string | Date, job: CronCommand)
+  registerJob(schedule: string | Date, job: CronCommand);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "declarationDir": "./dist",
     "sourceMap": true,
     "experimentalDecorators": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Changes

1. Perform builds with pure tsc and remove gulp entirely
2. Switch from TSLint to ESLint
3. Implement the new styleguide we use with eslint
4. Let linter errors cause Jenkins build failures

## Issues

Part of https://github.com/essential-projects/essential_projects_meta/issues/1

PR: #2

## How to test the changes

- Running `npm run build` works a great deal faster than before
- Linting is now possible and works as expected
- The Jenkins Builds will also run approx. twice as fast as before